### PR TITLE
Fix a shield for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/Zimtir/SENT-template
 ![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/sent-template/dev/svelte?color=green)
 ![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/sent-template/dev/eslint?color=green)
 ![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/sent-template/dev/prettier?color=green)
-![GitHub package.json dependency version (prod)](https://img.shields.io/github/package-json/dependency-version/Zimtir/sent-template/typescript?color=green)
+![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/sent-template/dev/typescript?color=green)
 
 ## List of features:
 

--- a/package.json
+++ b/package.json
@@ -106,5 +106,5 @@
     "type": "git",
     "url": "https://github.com/Zimtir/SENT-template.git"
   },
-  "version": "0.1.2"
+  "version": "0.1.3"
 }


### PR DESCRIPTION
## Version: 0.1.3

## Description:

This change provides a fix of mistake for shield at readme.md file for version of Typescript package

## TODO:

- [x] Self-review
- [x] Manual testing
- [x] Labels
- [x] Issues
- [x] No pre-commit errors

## Additional information (screenshots, links, etc)

from: 

![image](https://user-images.githubusercontent.com/32175240/89109103-f61b3980-d446-11ea-877e-435c52d5f92f.png)


to

![image](https://user-images.githubusercontent.com/32175240/89109096-e4d22d00-d446-11ea-8bcb-721f567e82bc.png)
