### PR TITLE
Disable CSP at Helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sent-template",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -158,5 +158,5 @@
     "type": "git",
     "url": "https://github.com/Zimtir/SENT-template.git"
   },
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/src/backend/tools/setup.ts
+++ b/src/backend/tools/setup.ts
@@ -94,4 +94,7 @@ export const setupErrorHandler = (): RequestHandler => {
   return errorThrower
 }
 
-export const setupHelmet = (): RequestHandler => helmet()
+export const setupHelmet = (): RequestHandler =>
+  helmet({
+    contentSecurityPolicy: false,
+  })


### PR DESCRIPTION
## Version: 0.4.1

## Description:

Remove of CSP at Helmet because it blocks service-worker.js injection at template.html

## TODO:

- [x] Self-review
- [x] Manual testing
- [x] Labels
- [x] Issues
- [x] No pre-commit errors

## The following list of issues will be closed:

## Additional information (screenshots, links, etc)
